### PR TITLE
Upgrade to flutter 2.10.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1.4.0
         with:
-          flutter-version: 2.0.5
+          flutter-version: 2.10.0
           channel: "stable"
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1.4.0
+      - uses: subosito/flutter-action@v1
         with:
-          flutter-version: 2.10.0
-          channel: "stable"
+          flutter-version: '2.10.0'
+          channel: 'stable'
 
       - name: Install Dependencies
         run: flutter pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.8
+
+- Support Flutter 2.10.0
+  Now its default Android Target is Android 12 (sdk 31).
+
 # 0.1.7
 
 - **Android:** Migrated from jcenter to mavenCentral

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# optimizely_dart
+# optimizely_dart ![Flutter 2.10.0](https://img.shields.io/badge/Flutter-2.10.0-blue)
 
 Flutter/Dart plugin for Optimizely native SDKs,
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.homexlabs.optimizely_dart_example"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="optimizely_dart_example"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -15,7 +15,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: optimizely_dart
 description: Flutter plugin for Optimizely native SDKs. Check feature flags and feature variables from your Optimizely project.
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/HomeXLabs/optimizely-dart
 repository: https://github.com/HomeXLabs/optimizely-dart
 


### PR DESCRIPTION
## Description
Upgrade Flutter 2.10.0 - Now its default Android Target is Android 12 (sdk 31).

https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects#full-flutter-app-migration


## Type of Change:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance or Refactor

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I added tests to cover my changes
- [x] I rebased changes with master so that they can be merged easily
- [x] I have updated the documentation accordingly (if applicable)